### PR TITLE
Downgrade the Microsoft Abstractions Package to 2.1.1

### DIFF
--- a/src/Rules.Framework.Providers.InMemory/Rules.Framework.Providers.InMemory.csproj
+++ b/src/Rules.Framework.Providers.InMemory/Rules.Framework.Providers.InMemory.csproj
@@ -31,7 +31,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="Rules.Framework" Version="1.0.97" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.20.0.28934">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Hi Luís.
Could you review this pull request, please?
We have an dependency on microsoft.extensions.dependencyinjection.abstractions package to higher for some app.
It will be fine if it could be 2.1.1 instead of.
Many thanks.