### PR TITLE
Change 'include' glob pattern for query version tag

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -34,8 +34,7 @@ jobs:
       id: prev-version-tag
       uses: jimschubert/query-tag-action@v1
       with:
-        include: 'v*'
-        exclude: '*-rc*'
+        include: '*[0-9].*[0-9].*[0-9]*'
         commit-ish: 'HEAD~'
 
     - name: Find last commit message


### PR DESCRIPTION
Fixes the GitHub actions build target:

- Was seeking versions starting on v*
- Now it is able to seek versions on the format example 1.0.1-beta