### PR TITLE
Create missing documentation (Farfetch ownership requirements)

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at opensource@farfetch.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Description
+
+Please include here a description of the changes introduced by your new pull request.
+
+Remember, it is important to include as much information as possible on the context of the changes, so that we can properly review it.
+
+Also mention any issues to be closed with this pull request: Closes #(issue number).
+
+## Change checklist
+
+- [ ] Code follows the [code rules guidelines](../CONTRIBUTING.md#code-rules) of this project
+- [ ] Commit messages follow the [commit rules](../CONTRIBUTING.md#commit-rules) of this project
+- [ ] I have self-reviewed my changes before submitting this pull request
+- [ ] I have covered new/changed code with new tests and/or adjusted existent ones
+- [ ] I have made changes necessary to update the documentation accordingly
+
+Please also check the [_I want to contribute_](../CONTRIBUTING.md#i-want-to-contribute) guidelines and make sure you have done accordingly.
+
+## Disclaimer
+
+By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+Vulnerabilities are one of our main concerns
+
+## Reporting a Vulnerability
+
+Please, report any security vulnerability found to opensource@farfetch.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,7 @@ All commit messages should use following rules:
 - fix: solving bugs.
 - refactor: changes to source code that do not solve a bug or add a new feature.
 - test: adding new tests or fixing failing tests.
+- chore: a change on the repository's contents that does not affect production code nor does fit on the previously described types.
 
 ## Documentation rules
 

--- a/README.md
+++ b/README.md
@@ -90,3 +90,7 @@ Contributions are more than welcome! Submit comments, issues or pull requests, I
 Head over to [CONTRIBUTING](CONTRIBUTING.md) for further details.
 
 While I try to do the best I can, suggestions/contributions are deeply appreciated on documentation!
+
+## License
+
+[MIT License](LICENSE.md)


### PR DESCRIPTION
This merge request is adding missing files/information as required by Farfetch to gain ownership of a open source project.

Closes #30.
Closes #31.
Closes #32.
Closes #33.